### PR TITLE
Add various features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+settings/
+saves/
+
 *.msi

--- a/99-ellisys.rules
+++ b/99-ellisys.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="usb", ATTR{idVendor}=="1500", ATTR{idProduct}=="0200", MODE="666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="1500", ATTR{idProduct}=="0700", MODE="666"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM debian:bullseye
-
+ARG var_USERID=1000
+ENV USERID=${var_USERID}
 # Install wine
 RUN dpkg --add-architecture i386
 RUN apt-get update
-RUN apt-get install -y cabextract gnupg2
+RUN apt-get install -y cabextract gnupg2 unzip
 RUN apt-get install -y wget software-properties-common
 RUN wget -q -O - http://dl.winehq.org/wine-builds/winehq.key | apt-key add -
 RUN apt-add-repository http://dl.winehq.org/wine-builds/debian/
@@ -20,7 +21,8 @@ RUN mkdir -p /opt && chmod a+rwx /opt
 #####
 
 # Don't trust Windows software wih root-creds: Create an unprivileged user to run WINE stuff
-RUN useradd --uid 65000 --create-home --shell /bin/bash wineuser
+# Change the UID here to your userid `id --user` to avoid permission troubles with docker.
+RUN useradd -l --uid $USERID --create-home --shell /bin/bash wineuser
 
 # WINE will complain if the user doesn't own /opt/wineprefix.
 # Currently 'wineuser' is the owner, but we propagate user-id through Docker.
@@ -37,5 +39,5 @@ USER wineuser
 WORKDIR /tmp
 RUN mkdir -p /opt/wineprefix && chmod a+rwx /opt/wineprefix
 
-# Tell docker to use this as entrypoint for 'docker run', rather than "/bin/sh -c"
+# Tell docker to use this as the entry point for 'docker run', rather than "/bin/sh -c"
 ENTRYPOINT ["/assets/entry.sh"]

--- a/assets/entry.sh
+++ b/assets/entry.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # set -x; echo "entry.sh: $@"; env
-export WINEARCH=win32
+export WINEARCH=win64
 export WINEPREFIX=/opt/wineprefix
 
 exec $@

--- a/assets/install_ellisys.sh
+++ b/assets/install_ellisys.sh
@@ -1,16 +1,25 @@
 #!/bin/bash
 
-MSI_PATH="/assets/tmp/bta.msi"    # Store outside docker-image
+BTA_PATH="/assets/tmp/bta.msi"    # Store outside docker-image
+BTA_URL="https://www.ellisys.com/better_analysis/bta_get.php"
+#BTA_URL="https://www.ellisys.com/better_analysis/bta_get.php?v=5.0.8393.22590"
+EBQ_VIEWER_PATH="/assets/tmp/EBQ_viewer.exe"    # Store outside docker-image
 INSTALL_FOLDER="C:\Ellisys"
+BTA_INSTALL_FOLDER="${INSTALL_FOLDER}\Ellisys Bluetooth Analyzer"
+EBQ_VIEWER_INSTALL_FOLDER="${INSTALL_FOLDER}\Ellisys Bluetooth Qualifier Viewer"
 
-test -e "${MSI_PATH}" || {
+BTA_SIZE=$(wc -c $BTA_PATH)
+BTA_DL_SIZE=$(wget $BTA_URL --spider --server-response -O - 2>&1 | sed -ne '/Content-Length/{s/.*: //;p}')
+if ( test -e "${BTA_PATH}" && [ "${BTA_SIZE%% *}" = "$BTA_DL_SIZE" ])
+then
+    echo "### Already have the latest installer, skipping download"
+else
     echo "### Could not find Ellisys installer. Downloading..."
-    wget -O "${MSI_PATH}" "https://www.ellisys.com/better_analysis/bta_get.php"
-#   wget -O "${MSI_PATH}" "https://www.ellisys.com/better_analysis/bta_get.php?v=5.0.7690.40428"
-}
+    wget -O "${BTA_PATH}" "${BTA_URL}"
+fi
 
-test -e "${MSI_PATH}" || {
-    echo "### Could not find Ellisys installer at '${MSI_PATH}'. Giving up."
+test -e "${BTA_PATH}" || {
+    echo "### Could not find Ellisys installer at '${BTA_PATH}'. Giving up."
     exit 1
 }
 
@@ -18,19 +27,18 @@ test -e "${MSI_PATH}" || {
 # msiexec args documentation: https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/msiexec
 # Properties can also be specified in a key=value fashion
 # Install dir is a property, but many different conventions exists -- try them all
-echo "### Installing Ellisys at '${INSTALL_FOLDER}'..."
-wine msiexec \
-    /i "${MSI_PATH}" \
+echo "### Installing Ellisys Bluetooth Analyzer at '${BTA_INSTALL_FOLDER}'..."
+wine64 msiexec \
+    /i "${BTA_PATH}" \
     /passive \
-    TARGETDIR="${INSTALL_FOLDER}" \
-    INSTALLDIR="${INSTALL_FOLDER}" \
-    INSTALLFOLDER="${INSTALL_FOLDER}" \
-    INSTALLPATH="${INSTALL_FOLDER}" \
-    INSTALLLOCATION="${INSTALL_FOLDER}" \
-    APPLICATIONFOLDER="${INSTALL_FOLDER}" \
-    APPDIR="${INSTALL_FOLDER}" \
-&& echo "### Installed Ellisys at '${INSTALL_FOLDER}'."
-chmod -R a+rxw "$WINEPREFIX"  # Ensure everybody can access newly installed stuff
+    TARGETDIR="${BTA_INSTALL_FOLDER}" \
+    INSTALLDIR="${BTA_INSTALL_FOLDER}" \
+    INSTALLFOLDER="${BTA_INSTALL_FOLDER}" \
+    INSTALLPATH="${BTA_INSTALL_FOLDER}" \
+    INSTALLLOCATION="${BTA_INSTALL_FOLDER}" \
+    APPLICATIONFOLDER="${BTA_INSTALL_FOLDER}" \
+    APPDIR="${BTA_INSTALL_FOLDER}" \
+&& echo "### Installed Ellisys at '${BTA_INSTALL_FOLDER}'."
 
 {
 cat << EOF
@@ -43,7 +51,44 @@ myself="\$(id --user):\$(id --group)"
 
 ln -s /mnt/host_root "\${WINEPREFIX}/dosdevices/h:"
 
-wine "${INSTALL_FOLDER}\Ellisys.BluetoothAnalyzer.exe" \$@
+wine64 "${BTA_INSTALL_FOLDER}\Ellisys.BluetoothAnalyzer.exe" \$@
 EOF
 } > "/opt/ellisys.sh"
 chmod +x "/opt/ellisys.sh"
+
+
+test -e "${EBQ_VIEWER_PATH}" || {
+    echo "### Could not find Ellisys installer. Downloading..."
+    wget -O "${EBQ_VIEWER_PATH}.zip" "https://www.ellisys.com/better_analysis/ebq_viewer_8424.zip"
+    unzip "${EBQ_VIEWER_PATH}.zip"
+    mv EllisysBluetoothQualifierViewerInstaller* "${EBQ_VIEWER_PATH}"
+    rm "${EBQ_VIEWER_PATH}.zip"
+}
+
+test -e "${EBQ_VIEWER_PATH}" || {
+    echo "### Could not find Ellisys installer at '${EBQ_VIEWER_PATH}'. Giving up."
+    exit 1
+}
+
+echo "### Installing Ellisys Bluetooth Qualifier Viewer at '${EBQ_VIEWER_INSTALL_FOLDER}'..."
+wine64 ${EBQ_VIEWER_PATH} /VERYSILENT /DIR="${EBQ_VIEWER_INSTALL_FOLDER}"
+
+{
+cat << EOF
+#!/bin/bash
+
+# wineuser owns $WINEPREFIX folder, so only {root,wineuser} can change ownership to our user
+myself="\$(id --user):\$(id --group)"
+/tmp/chown_suid "\$myself" "\$WINEPREFIX"                         # make wine happy
+/tmp/chown_suid "\$myself" /tmp/chown_suid && rm /tmp/chown_suid  # clean-up
+
+ln -s /mnt/host_root "\${WINEPREFIX}/dosdevices/h:"
+
+wine64 "${EBQ_VIEWER_INSTALL_FOLDER}\Ellisys.BQ1.TesterViewer.exe" \$@
+EOF
+} > "/opt/ebq_viewer.sh"
+chmod +x "/opt/ebq_viewer.sh"
+
+chmod -R a+rxw "$WINEPREFIX"  # Ensure everybody can access newly installed stuff
+
+

--- a/assets/install_tricks.sh
+++ b/assets/install_tricks.sh
@@ -2,7 +2,11 @@
 
 # See https://appdb.winehq.org/objectManager.php?sClass=version&iId=34219
 WINEDLLOVERRIDES="mscoree,mshtml=" wineboot --init
-winetricks --unattended --force dotnet48
+winetricks --unattended --force tahoma gdiplus
+
+#the EBQ viewer requires DirectX
+winetricks --unattended --force d3dcompiler_47
+
 chmod -R a+rxw "$WINEPREFIX"  # Ensure everybody can access newly installed stuff
 
 rm -rf /tmp/*wine*

--- a/install_udev_rules.sh
+++ b/install_udev_rules.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ "$EUID" -ne 0 ]
+  then echo "Must be run as root"
+  exit
+fi
+
+cp 99-ellisys.rules /etc/udev/rules.d/
+udevadm control --reload-rules
+udevadm trigger

--- a/readme.md
+++ b/readme.md
@@ -31,5 +31,15 @@ Basically you call the script with a subcommand, e.g.:
 
     ./wine_docker.sh ellisys
     ./wine_docker.sh ellisys dump.btt
+    ./wine_docker.sh ebq_viewer dump.thd
     ./wine_docker.sh interactive   # default behavior. Gives you a shell inside
 
+# Troubleshooting
+
+* Ellysis crashes when you try to open / save file </br>
+    Change the docker user id in the docker image and recompile it.
+
+* ebq_viewer crashes </br>
+    Run it with a file first. After that the version without a file will work too.
+    installing d3dx9 in addition to d3dcompiler_47 might fix it as well, but
+    it's hard to reproduce this issue.


### PR DESCRIPTION
This commit is a squash of an internal fork.
Some of the contributors have requested to remain
anonymous so the changes are not as fine grained
as they could be.

The list of changes is:
* Change WINEARCH to win64. This makes better use of modern CPUs.
* Make Ellisys USB devices usable. bullseye ships with a recent libusb version that can be used by wine. Previously errors such as "undefined symbol: libusb_set_option" would show up when running with "WINEDEBUG=+module". There are also udev rules to allow anyone to access the device types we've had access to locally.
* Mount a folder to keep settings between runs.
* Add saving captures and web control. Change the userid to 1000 as this is the userid of most users. Having your userid match inside and outside of docker fixes permission issue that causes winefile to crash. Users with a different UID should change this before compiling.
* Add volume for saved files. Files in this location can also be opened from within Ellisys BTA.
* Add port 8080 for the Ellisys BTA web interface.
* Install the EBQ Viewer as well. This requires a shader compiler for HLSL. That is not available in wine so the d3dcompiler_47 is installed. A side effect of this is that the GUI looks more modern.
* Use --no-log-init flag with adduser Using the --no-log-init flag (-l) stops the container from claiming the HD space if a high userid is used. Also added an improvement for setting the uid automatically to the user linux user account when running the ./wine_docker.sh script to build the image.
* Pre-checking the download size and comparing it with downloaded file to always fetch the latest ebq image.

Contributors (alphabetical):
Ivan Iushkov <ivan.iushkov@nordicsemi.no>
Timothy Keys <timothy.keys@nordicsemi.no>
Jan Müller <jan.mueller@nordicsemi.no>
Bernhard Wimmer <bernhard.wimmer@nordicsemi.no>
and others.